### PR TITLE
Add deployment example

### DIFF
--- a/opentelemetry/deployment/README.md
+++ b/opentelemetry/deployment/README.md
@@ -3,10 +3,10 @@
 Overall, this configuration sets up an OpenTelemetry collector deployed as a Deployment that receives Jaeger, OTLP, OpenCensus and Zipkin traces, adds Kubernetes attributes, and exports the traces to Tempo via OTLP.
 
 ## How to run
-1. Modify the namespace from the `otel-collector` `ClusterRoleBinding` from `deployment-otelcol.yaml` to your namespace. Replace the `<OPENTELEMETRY_NAMESPACE>` string with the name of the desired namespace.
-1. Deploy the resources from the `deployment-otelcol.yaml` manifest file:
+1. Modify the `<OPENSHIFT API ADDRESS>` and `<OPENSHIFT TOKEN>` values from the `resourcedetection/openshift` processor
+1. Deploy the resources from the `otelcol.yaml` manifest file:
     ```sh
-    oc apply -f deployment-otelcol.yaml
+    oc apply -f otelcol.yaml
     ```
 
 
@@ -15,7 +15,11 @@ This example configuration defines an OpenTelemetry Collector in an OpenShift en
 
 The collector is configured with a receiver for Jaeger traces over the Thrift HTTP protocol, OpenCensus traces over the OpenCensus protocol, Zipkin traces over the Zipkin protocol and OTLP traces over the GRPC protocol.
 
-It also has a processor that adds Kubernetes attributes to the spans based on the node they originated from. This filtering is done to ensure that your collector only retrieves pods from the node where the collector is installed. It allows you to avoid keeping track of a long list of pods if you have a large cluster.
+It also has different processors:
+* `k8sattributes`: adds Kubernetes attributes to the spans based on the node they originated from.
+* `resourcedetectionprocessor`: adds information detected from the host to the traces. This example enables two detectors: `env` (reads resource information from the `OTEL_RESOURCE_ATTRIBUTES` env variable) and `openshift` (reads from the OpenShift API to retrieve information).
+
+https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
 
 Finally, the collector is configured with an exporter that sends traces to the tempo-simplest-distributor endpoint over the OTLP protocol. This exporter has TLS enabled, using a CA file.
 

--- a/opentelemetry/deployment/README.md
+++ b/opentelemetry/deployment/README.md
@@ -14,7 +14,3 @@ It also has different processors:
 * [`resourcedetectionr`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor): adds information detected from the host to the traces. This example enables two detectors: `env` (reads resource information from the `OTEL_RESOURCE_ATTRIBUTES` env variable) and `openshift` (reads from the OpenShift API to retrieve information).
 
 Keep in mind that the sequence of the processors determines how the data is processed.
-
-Finally, the collector is configured with an exporter that sends traces to the tempo-simplest-distributor endpoint over the OTLP protocol. This exporter has TLS enabled, using a CA file.
-
-The `trusted-ca` `ConfigMap` is created [to contain a trusted CA](https://docs.openshift.com/container-platform/4.12/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki). This CA is mounted in the `OpenTelemetryCollector` instance using `Volumes`.

--- a/opentelemetry/deployment/README.md
+++ b/opentelemetry/deployment/README.md
@@ -3,7 +3,6 @@
 Overall, this configuration sets up an OpenTelemetry collector deployed as a Deployment that receives Jaeger, OTLP, OpenCensus and Zipkin traces, adds Kubernetes attributes, and exports the traces to Tempo via OTLP.
 
 ## How to run
-1. Modify the `<OPENSHIFT API ADDRESS>` and `<OPENSHIFT TOKEN>` values from the `resourcedetection/openshift` processor
 1. Deploy the resources from the `otelcol.yaml` manifest file:
     ```sh
     oc apply -f otelcol.yaml

--- a/opentelemetry/deployment/README.md
+++ b/opentelemetry/deployment/README.md
@@ -2,24 +2,17 @@
 
 Overall, this configuration sets up an OpenTelemetry collector deployed as a Deployment that receives Jaeger, OTLP, OpenCensus and Zipkin traces, adds Kubernetes attributes, and exports the traces to Tempo via OTLP.
 
-## How to run
-1. Deploy the resources from the `otelcol.yaml` manifest file:
-    ```sh
-    oc apply -f otelcol.yaml
-    ```
-
-
 ## Explanation
 This example configuration defines an OpenTelemetry Collector in an OpenShift environment. The collector is configured to run as a deployment in the cluster. The number of replicas will be determined by the `.spec.replicas` parameter or the parameters set in `.spec.autoscaler`.
 
-The collector is configured with a receiver for Jaeger traces over the Thrift HTTP protocol, OpenCensus traces over the OpenCensus protocol, Zipkin traces over the Zipkin protocol and OTLP traces over the GRPC protocol.
+The collector is configured with a receiver for Jaeger traces, OpenCensus traces over the OpenCensus protocol, Zipkin traces over the Zipkin protocol and OTLP traces over the GRPC protocol.
 
 It also has different processors:
+* [`batch`](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor): batching helps better compress the data and reduce the number of outgoing connections required to transmit the data.
 * [`k8sattributes`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor): adds Kubernetes attributes to the spans based on the node they originated from.
-* [`resourcedetectionprocessor`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor): adds information detected from the host to the traces. This example enables two detectors: `env` (reads resource information from the `OTEL_RESOURCE_ATTRIBUTES` env variable) and `openshift` (reads from the OpenShift API to retrieve information).
+* [`memory_limiter`](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor): prevents out of memory situations on the collector.
+* [`resourcedetectionr`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor): adds information detected from the host to the traces. This example enables two detectors: `env` (reads resource information from the `OTEL_RESOURCE_ATTRIBUTES` env variable) and `openshift` (reads from the OpenShift API to retrieve information).
 
 Finally, the collector is configured with an exporter that sends traces to the tempo-simplest-distributor endpoint over the OTLP protocol. This exporter has TLS enabled, using a CA file.
 
 The `trusted-ca` `ConfigMap` is created [to contain a trusted CA](https://docs.openshift.com/container-platform/4.12/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki). This CA is mounted in the `OpenTelemetryCollector` instance using `Volumes`.
-
-

--- a/opentelemetry/deployment/README.md
+++ b/opentelemetry/deployment/README.md
@@ -1,0 +1,24 @@
+# Deployment
+
+Overall, this configuration sets up an OpenTelemetry collector deployed as a Deployment that receives Jaeger, OTLP, OpenCensus and Zipkin traces, adds Kubernetes attributes, and exports the traces to Tempo via OTLP.
+
+## How to run
+1. Modify the namespace from the `otel-collector` `ClusterRoleBinding` from `deployment-otelcol.yaml` to your namespace. Replace the `<OPENTELEMETRY_NAMESPACE>` string with the name of the desired namespace.
+1. Deploy the resources from the `deployment-otelcol.yaml` manifest file:
+    ```sh
+    oc apply -f deployment-otelcol.yaml
+    ```
+
+
+## Explanation
+This example configuration defines an OpenTelemetry Collector in an OpenShift environment. The collector is configured to run as a deployment in the cluster. The number of replicas will be determined by the `.spec.replicas` parameter or the parameters set in `.spec.autoscaler`.
+
+The collector is configured with a receiver for Jaeger traces over the Thrift HTTP protocol, OpenCensus traces over the OpenCensus protocol, Zipkin traces over the Zipkin protocol and OTLP traces over the GRPC protocol.
+
+It also has a processor that adds Kubernetes attributes to the spans based on the node they originated from. This filtering is done to ensure that your collector only retrieves pods from the node where the collector is installed. It allows you to avoid keeping track of a long list of pods if you have a large cluster.
+
+Finally, the collector is configured with an exporter that sends traces to the tempo-simplest-distributor endpoint over the OTLP protocol. This exporter has TLS enabled, using a CA file.
+
+The `trusted-ca` `ConfigMap` is created [to contain a trusted CA](https://docs.openshift.com/container-platform/4.12/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki). This CA is mounted in the `OpenTelemetryCollector` instance using `Volumes`.
+
+

--- a/opentelemetry/deployment/README.md
+++ b/opentelemetry/deployment/README.md
@@ -15,10 +15,8 @@ This example configuration defines an OpenTelemetry Collector in an OpenShift en
 The collector is configured with a receiver for Jaeger traces over the Thrift HTTP protocol, OpenCensus traces over the OpenCensus protocol, Zipkin traces over the Zipkin protocol and OTLP traces over the GRPC protocol.
 
 It also has different processors:
-* `k8sattributes`: adds Kubernetes attributes to the spans based on the node they originated from.
-* `resourcedetectionprocessor`: adds information detected from the host to the traces. This example enables two detectors: `env` (reads resource information from the `OTEL_RESOURCE_ATTRIBUTES` env variable) and `openshift` (reads from the OpenShift API to retrieve information).
-
-https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
+* [`k8sattributes`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor): adds Kubernetes attributes to the spans based on the node they originated from.
+* [`resourcedetectionprocessor`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor): adds information detected from the host to the traces. This example enables two detectors: `env` (reads resource information from the `OTEL_RESOURCE_ATTRIBUTES` env variable) and `openshift` (reads from the OpenShift API to retrieve information).
 
 Finally, the collector is configured with an exporter that sends traces to the tempo-simplest-distributor endpoint over the OTLP protocol. This exporter has TLS enabled, using a CA file.
 

--- a/opentelemetry/deployment/README.md
+++ b/opentelemetry/deployment/README.md
@@ -13,6 +13,8 @@ It also has different processors:
 * [`memory_limiter`](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor): prevents out of memory situations on the collector.
 * [`resourcedetectionr`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor): adds information detected from the host to the traces. This example enables two detectors: `env` (reads resource information from the `OTEL_RESOURCE_ATTRIBUTES` env variable) and `openshift` (reads from the OpenShift API to retrieve information).
 
+Keep in mind that the sequence of the processors determines how the data is processed.
+
 Finally, the collector is configured with an exporter that sends traces to the tempo-simplest-distributor endpoint over the OTLP protocol. This exporter has TLS enabled, using a CA file.
 
 The `trusted-ca` `ConfigMap` is created [to contain a trusted CA](https://docs.openshift.com/container-platform/4.12/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki). This CA is mounted in the `OpenTelemetryCollector` instance using `Volumes`.

--- a/opentelemetry/deployment/deployment-otelcol.yaml
+++ b/opentelemetry/deployment/deployment-otelcol.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector-deployment
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: trusted-ca
+data: {}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-collector
+rules:
+- apiGroups: [""]
+  resources: ["pods", "namespaces"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-collector
+subjects:
+- kind: ServiceAccount
+  name: otel-collector-deployment
+  namespace: <OPENTELEMETRY_NAMESPACE>
+roleRef:
+  kind: ClusterRole
+  name: otel-collector
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otlp-collector
+spec:
+  mode: deployment
+  serviceAccount: otel-collector-deployment
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: trusted-ca
+        items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+  volumeMounts:
+    - name: trusted-ca
+      mountPath: /etc/pki/ca-trust/extracted/pem
+      readOnly: true
+  config: |
+    receivers:
+      jaeger:
+        protocols:
+          thrift_http:
+      opencensus:
+      otlp:
+        protocols:
+          grpc:
+      zipkin:
+    processors:
+      k8sattributes:
+    exporters:
+      otlp:
+        endpoint: "tempo-simplest-distributor:4317"
+        tls:
+          ca_file: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+    service:
+      pipelines:
+        traces:
+          receivers: [jaeger]
+          processors: [k8sattributes]
+          exporters: [otlp]

--- a/opentelemetry/deployment/otelcol.yaml
+++ b/opentelemetry/deployment/otelcol.yaml
@@ -25,7 +25,7 @@ metadata:
   namespace: otel-collector-example
 rules:
 - apiGroups: [""]
-  resources: ["pods", "namespaces"]
+  resources: ["pods", "namespaces", "infrastructures"]
   verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -83,14 +83,12 @@ spec:
         detectors: [openshift]
         timeout: 2s
         openshift:
-          address: "<OPENSHIFT API ADDRESS>"
-          token: "<OPENSHIFT TOKEN>"
           tls:
             insecure: false
             ca_file: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
     exporters:
       otlp:
-        endpoint: "tempo-simplest-distributor:4317"
+        endpoint: "tempo-simplest-distributor.svc:4317"
         tls:
           ca_file: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
     service:

--- a/opentelemetry/deployment/otelcol.yaml
+++ b/opentelemetry/deployment/otelcol.yaml
@@ -1,7 +1,13 @@
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: otel-collector-example
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: otel-collector-deployment
+  namespace: otel-collector-example
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -9,12 +15,14 @@ metadata:
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"
   name: trusted-ca
+  namespace: otel-collector-example
 data: {}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: otel-collector
+  namespace: otel-collector-example
 rules:
 - apiGroups: [""]
   resources: ["pods", "namespaces"]
@@ -27,7 +35,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: otel-collector-deployment
-  namespace: <OPENTELEMETRY_NAMESPACE>
+  namespace: otel-collector-example
 roleRef:
   kind: ClusterRole
   name: otel-collector
@@ -36,7 +44,8 @@ roleRef:
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:
-  name: otlp-collector
+  name: otel
+  namespace: otel-collector-example
 spec:
   mode: deployment
   serviceAccount: otel-collector-deployment
@@ -55,14 +64,30 @@ spec:
     receivers:
       jaeger:
         protocols:
+          grpc:
+          thrift_binary:
+          thrift_compact:
           thrift_http:
       opencensus:
       otlp:
         protocols:
           grpc:
+          http:
       zipkin:
     processors:
       k8sattributes:
+      resourcedetection/env:
+        detectors: [env]
+        timeout: 2s
+      resourcedetection/openshift:
+        detectors: [openshift]
+        timeout: 2s
+        openshift:
+          address: "<OPENSHIFT API ADDRESS>"
+          token: "<OPENSHIFT TOKEN>"
+          tls:
+            insecure: false
+            ca_file: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
     exporters:
       otlp:
         endpoint: "tempo-simplest-distributor:4317"
@@ -71,6 +96,6 @@ spec:
     service:
       pipelines:
         traces:
-          receivers: [jaeger]
-          processors: [k8sattributes]
+          receivers: [jaeger, opencensus, otlp, opencensus]
+          processors: [k8sattributes, resourcedetection/env, resourcedetection/openshift]
           exporters: [otlp]

--- a/opentelemetry/deployment/otelcol.yaml
+++ b/opentelemetry/deployment/otelcol.yaml
@@ -99,5 +99,5 @@ spec:
       pipelines:
         traces:
           receivers: [jaeger, opencensus, opencensus, otlp, zipkin]
-          processors: [batch, k8sattributes, memory_limiter, resourcedetection]
+          processors: [memory_limiter, k8sattributes, resourcedetection, batch]
           exporters: [otlp]

--- a/opentelemetry/deployment/otelcol.yaml
+++ b/opentelemetry/deployment/otelcol.yaml
@@ -9,15 +9,6 @@ metadata:
   name: otel-collector-deployment
   namespace: otel-collector-example
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    config.openshift.io/inject-trusted-cabundle: "true"
-  name: trusted-ca
-  namespace: otel-collector-example
-data: {}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -49,17 +40,6 @@ metadata:
 spec:
   mode: deployment
   serviceAccount: otel-collector-deployment
-  volumes:
-    - name: trusted-ca
-      configMap:
-        name: trusted-ca
-        items:
-          - key: ca-bundle.crt
-            path: tls-ca-bundle.pem
-  volumeMounts:
-    - name: trusted-ca
-      mountPath: /etc/pki/ca-trust/extracted/pem
-      readOnly: true
   config: |
     receivers:
       jaeger:
@@ -87,14 +67,9 @@ spec:
         detectors: [openshift]
         timeout: 2s
         openshift:
-          tls:
-            insecure: false
-            ca_file: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
     exporters:
       otlp:
         endpoint: "tempo-simplest-distributor.svc:4317"
-        tls:
-          ca_file: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
     service:
       pipelines:
         traces:

--- a/opentelemetry/deployment/otelcol.yaml
+++ b/opentelemetry/deployment/otelcol.yaml
@@ -75,11 +75,15 @@ spec:
           http:
       zipkin:
     processors:
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
       k8sattributes:
-      resourcedetection/env:
-        detectors: [env]
-        timeout: 2s
-      resourcedetection/openshift:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 50
+        spike_limit_percentage: 30
+      resourcedetection:
         detectors: [openshift]
         timeout: 2s
         openshift:
@@ -94,6 +98,6 @@ spec:
     service:
       pipelines:
         traces:
-          receivers: [jaeger, opencensus, otlp, opencensus]
-          processors: [k8sattributes, resourcedetection/env, resourcedetection/openshift]
+          receivers: [jaeger, opencensus, opencensus, otlp, zipkin]
+          processors: [batch, k8sattributes, memory_limiter, resourcedetection]
           exporters: [otlp]

--- a/opentelemetry/deployment/otelcol.yaml
+++ b/opentelemetry/deployment/otelcol.yaml
@@ -72,5 +72,5 @@ spec:
       pipelines:
         traces:
           receivers: [jaeger, opencensus, opencensus, otlp, zipkin]
-          processors: [memory_limiter, k8sattributes, resourcedetection]
+          processors: [memory_limiter, k8sattributes, resourcedetection, batch]
           exporters: [otlp]

--- a/opentelemetry/sidecar/otelcol.yaml
+++ b/opentelemetry/sidecar/otelcol.yaml
@@ -6,7 +6,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: otel-collector-deployment
+  name: otel-collector-sidecar
   namespace: otel-collector-example
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -15,7 +15,7 @@ metadata:
   name: otel-collector
   namespace: otel-collector-example
 rules:
-- apiGroups: ["", "config.openshift.io"]
+- apiGroups: [""]
   resources: ["pods", "namespaces", "infrastructures"]
   verbs: ["get", "watch", "list"]
 ---
@@ -25,7 +25,7 @@ metadata:
   name: otel-collector
 subjects:
 - kind: ServiceAccount
-  name: otel-collector-deployment
+  name: otel-collector-sidecar
   namespace: otel-collector-example
 roleRef:
   kind: ClusterRole
@@ -38,8 +38,8 @@ metadata:
   name: otel
   namespace: otel-collector-example
 spec:
-  mode: deployment
-  serviceAccount: otel-collector-deployment
+  mode: sidecar
+  serviceAccount: otel-collector-sidecar
   config: |
     receivers:
       jaeger:
@@ -56,21 +56,15 @@ spec:
       zipkin:
     processors:
       batch:
-      k8sattributes:
       memory_limiter:
-        check_interval: 1s
-        limit_percentage: 50
-        spike_limit_percentage: 30
       resourcedetection:
         detectors: [openshift]
     exporters:
       otlp:
-        endpoint: "tempo-simplest-distributor:4317"
-        tls:
-          insecure: true
+        endpoint: "tempo-simplest-distributor.svc:4317"
     service:
       pipelines:
         traces:
-          receivers: [jaeger, opencensus, opencensus, otlp, zipkin]
-          processors: [memory_limiter, k8sattributes, resourcedetection]
+          receivers: [jaeger, opencensus, otlp, zipkin]
+          processors: [memory_limiter, resourcedetection, batch]
           exporters: [otlp]


### PR DESCRIPTION
This PR adds an example of how to use the OpenTelemetry Collector (Red Hat Distribution) as deployment.